### PR TITLE
Feat: AWS S3 연동, 사진 메타데이터 추출

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,26 @@ dependencies {
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // AWS - 중복된 의존성 제거 및 간소화
+    implementation platform('software.amazon.awssdk:bom:2.20.56')
+    implementation 'software.amazon.awssdk:s3'
+    implementation 'software.amazon.awssdk:url-connection-client'
+
+    // EXIF/메타데이터 - 안정적인 버전 사용
+    implementation 'com.drewnoakes:metadata-extractor:2.18.0'
+
+    // TwelveMonkeys ImageIO - 안정적인 버전 사용
+    implementation 'com.twelvemonkeys.imageio:imageio-core:3.9.4'
+    implementation 'com.twelvemonkeys.imageio:imageio-jpeg:3.9.4'
+    implementation 'com.twelvemonkeys.imageio:imageio-tiff:3.9.4'
+
+    // Apache Commons Imaging (실험적 의존성 제거)
+    implementation 'org.apache.commons:commons-imaging:1.0-alpha3'
+
+    // 이미지 처리 관련 라이브러리 - 안정적인 버전으로 변경
+    implementation 'net.coobird:thumbnailator:0.4.19'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/ssafy/retrip/api/controller/image/ImageController.java
+++ b/src/main/java/ssafy/retrip/api/controller/image/ImageController.java
@@ -1,0 +1,28 @@
+package ssafy.retrip.api.controller.image;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import ssafy.retrip.api.controller.image.response.ImageResponseDto;
+import ssafy.retrip.api.service.image.ImageService;
+
+import java.io.IOException;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class ImageController {
+
+    private final ImageService imageService;
+
+    @PostMapping("/uploads")
+    public ResponseEntity<List<ImageResponseDto>> uploadMultipleImages(
+            @RequestParam("images") List<MultipartFile> images,
+            @RequestParam(value = "dirName", defaultValue = "images") String dirName) throws IOException {
+        
+        List<ImageResponseDto> uploadedImages = imageService.uploadImages(images, dirName);
+        return ResponseEntity.ok(uploadedImages);
+    }
+}

--- a/src/main/java/ssafy/retrip/api/controller/image/response/ImageResponseDto.java
+++ b/src/main/java/ssafy/retrip/api/controller/image/response/ImageResponseDto.java
@@ -1,0 +1,39 @@
+package ssafy.retrip.api.controller.image.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssafy.retrip.domain.image.Image;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ImageResponseDto {
+    private Long id;
+    private String imageUrl;
+    private String originalFileName;
+    private String contentType;
+    private Long fileSize;
+    private LocalDateTime takenDate;
+    private String location;
+    private Double latitude;
+    private Double longitude;
+    
+    public static ImageResponseDto from(Image image) {
+        return ImageResponseDto.builder()
+                .id(image.getId())
+                .imageUrl(image.getImageUrl())
+                .originalFileName(image.getOriginalFileName())
+                .contentType(image.getContentType())
+                .fileSize(image.getFileSize())
+                .takenDate(image.getTakenDate())
+                .location(image.getLocation())
+                .latitude(image.getLatitude())
+                .longitude(image.getLongitude())
+                .build();
+    }
+}

--- a/src/main/java/ssafy/retrip/api/service/image/ImageService.java
+++ b/src/main/java/ssafy/retrip/api/service/image/ImageService.java
@@ -1,0 +1,256 @@
+package ssafy.retrip.api.service.image;
+
+import com.drew.imaging.ImageMetadataReader;
+import com.drew.imaging.ImageProcessingException;
+import com.drew.lang.GeoLocation;
+import com.drew.metadata.Metadata;
+import com.drew.metadata.exif.ExifSubIFDDirectory;
+import com.drew.metadata.exif.GpsDirectory;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.coobird.thumbnailator.Thumbnails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import ssafy.retrip.aws.S3Uploader;
+import ssafy.retrip.api.controller.image.response.ImageResponseDto;
+import ssafy.retrip.domain.image.Image;
+import ssafy.retrip.domain.image.ImageRepository;
+
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final S3Uploader s3Uploader;
+    private final ImageRepository imageRepository;
+
+    @Transactional
+    public List<ImageResponseDto> uploadImages(List<MultipartFile> images, String dirName) throws IOException {
+        List<ImageResponseDto> uploadedImages = new ArrayList<>();
+        List<String> errors = new ArrayList<>();
+        
+        for (MultipartFile image : images) {
+            try {
+                if (!image.isEmpty()) {
+                    // 파일을 로컬에 임시 저장 (HEIC 처리 포함)
+                    Optional<File> convertedFile = processAndConvertFile(image);
+                    
+                    if (convertedFile.isPresent()) {
+                        File file = convertedFile.get();
+                        
+                        // 메타데이터 추출
+                        ImageMetadata metadata = extractMetadata(file);
+                        
+                        // 메타데이터가 없을 경우 기본값 사용
+                        if (metadata.takenDate == null) {
+                            log.warn("이미지에 촬영 시간 정보가 없습니다: {}. 현재 시간을 사용합니다.", image.getOriginalFilename());
+                            metadata.takenDate = LocalDateTime.now();
+                        }
+                        
+                        if (metadata.latitude == null || metadata.longitude == null) {
+                            log.warn("이미지에 위치 정보가 없습니다: {}. 가능한 경우 파일명 또는 다른 메타데이터에서 추출합니다.", image.getOriginalFilename());
+                            // 파일명에서 위치 정보 추출 시도
+                            extractLocationFromFilename(image.getOriginalFilename(), metadata);
+                        }
+                        
+                        // S3에 업로드
+                        String storedFileName = UUID.randomUUID() + "_" + image.getOriginalFilename();
+                        String imageUrl = s3Uploader.upload(image, dirName);
+                        
+                        // DB에 이미지 정보 저장
+                        Image savedImage = imageRepository.save(Image.builder()
+                                .imageUrl(imageUrl)
+                                .originalFileName(image.getOriginalFilename())
+                                .storedFileName(storedFileName)
+                                .contentType(image.getContentType())
+                                .fileSize(image.getSize())
+                                .takenDate(metadata.takenDate)
+                                .location(metadata.location)
+                                .latitude(metadata.latitude)
+                                .longitude(metadata.longitude)
+                                .dirName(dirName)
+                                .build());
+                        
+                        uploadedImages.add(ImageResponseDto.from(savedImage));
+                        
+                        // 파일 처리 후 임시 파일 삭제
+                        try {
+                            file.delete();
+                        } catch (Exception e) {
+                            log.warn("임시 파일 삭제 실패: {}", e.getMessage());
+                        }
+                    }
+                }
+            } catch (Exception e) {
+                log.error("이미지 처리 중 오류 발생: {}", image.getOriginalFilename(), e);
+                errors.add(image.getOriginalFilename() + ": " + e.getMessage());
+            }
+        }
+        
+        if (!errors.isEmpty()) {
+            log.warn("일부 이미지 처리 실패: {}", errors);
+        }
+        
+        return uploadedImages;
+    }
+    
+    // 파일 처리 및 변환 메소드 - HEIC 파일 처리 포함
+    private Optional<File> processAndConvertFile(MultipartFile file) throws IOException {
+        String filename = file.getOriginalFilename();
+        if (filename == null) {
+            return Optional.empty();
+        }
+        
+        // HEIC 파일 처리
+        if (filename.toLowerCase().endsWith(".heic") || 
+            (file.getContentType() != null && file.getContentType().toLowerCase().contains("heic"))) {
+            log.info("HEIC 파일 변환 시도: {}", filename);
+            
+            try {
+                // HEIC 파일을 임시 파일로 저장
+                File tempHeicFile = File.createTempFile("heic_", ".heic");
+                file.transferTo(tempHeicFile);
+                
+                // JPEG로 변환 시도 (TwelveMonkeys에 의존)
+                File jpegFile = File.createTempFile("converted_", ".jpg");
+                
+                try {
+                    // ImageIO를 사용하여 변환 시도
+                    BufferedImage image = ImageIO.read(tempHeicFile);
+                    if (image != null) {
+                        Thumbnails.of(image)
+                            .scale(1.0)
+                            .outputFormat("jpg")
+                            .toFile(jpegFile);
+                        
+                        tempHeicFile.delete();
+                        return Optional.of(jpegFile);
+                    }
+                } catch (Exception e) {
+                    log.warn("HEIC 변환 실패: {}. 대체 방법 시도", e.getMessage());
+                    
+                    // 대체 방법: 원본 파일 사용
+                    tempHeicFile.delete();
+                    jpegFile.delete();
+                    
+                    // 원본을 JPEG로 간주하고 그대로 처리
+                    File standardFile = File.createTempFile("original_", ".jpg");
+                    file.transferTo(standardFile);
+                    return Optional.of(standardFile);
+                }
+            } catch (Exception e) {
+                log.error("HEIC 파일 처리 중 오류 발생: {}", e.getMessage());
+            }
+        }
+        
+        // 일반 파일 처리 (기존 로직)
+        return s3Uploader.convert(file);
+    }
+
+    // 파일명에서 위치 정보 추출 시도
+    private void extractLocationFromFilename(String filename, ImageMetadata metadata) {
+        // 예: "Seoul_37.5665_126.9780.jpg" 형식의 파일명에서 위치 정보 추출
+        try {
+            String[] parts = filename.split("_");
+            if (parts.length >= 3) {
+                Double lat = Double.parseDouble(parts[parts.length - 2]);
+                Double lng = Double.parseDouble(parts[parts.length - 1].split("\\.")[0]);
+                
+                // 유효한 좌표값 확인
+                if (isValidCoordinate(lat, lng)) {
+                    metadata.latitude = lat;
+                    metadata.longitude = lng;
+                    metadata.location = "위도: " + lat + ", 경도: " + lng + " (파일명에서 추출)";
+                }
+            }
+        } catch (Exception e) {
+            log.debug("파일명에서 위치 정보 추출 실패: {}", filename);
+        }
+    }
+
+    private boolean isValidCoordinate(Double lat, Double lng) {
+        return lat != null && lng != null && 
+               lat >= -90 && lat <= 90 && 
+               lng >= -180 && lng <= 180;
+    }
+
+    private ImageMetadata extractMetadata(File imageFile) {
+        ImageMetadata metadata = new ImageMetadata();
+        
+        try {
+            Metadata rawMetadata = ImageMetadataReader.readMetadata(imageFile);
+            
+            // 1. 촬영 시간 추출 - 여러 태그로 시도
+            extractDateTimeInfo(rawMetadata, metadata);
+            
+            // 2. 위치 정보 추출 - GPS 데이터
+            extractGpsInfo(rawMetadata, metadata);
+            
+            // 3. 다른 유용한 메타데이터 추출 (향후 확장)
+            
+        } catch (ImageProcessingException | IOException e) {
+            log.error("이미지 메타데이터 추출 중 오류 발생", e);
+        }
+        
+        return metadata;
+    }
+
+    private void extractDateTimeInfo(Metadata rawMetadata, ImageMetadata metadata) {
+        // EXIF 디렉토리에서 날짜 추출 시도
+        ExifSubIFDDirectory exifDirectory = rawMetadata.getFirstDirectoryOfType(ExifSubIFDDirectory.class);
+        if (exifDirectory != null) {
+            // 1. 원본 촬영 시간 태그
+            Date date = exifDirectory.getDate(ExifSubIFDDirectory.TAG_DATETIME_ORIGINAL);
+            
+            // 2. 다른 날짜 관련 태그 시도
+            if (date == null) {
+                date = exifDirectory.getDate(ExifSubIFDDirectory.TAG_DATETIME);
+            }
+            if (date == null) {
+                date = exifDirectory.getDate(ExifSubIFDDirectory.TAG_DATETIME_DIGITIZED);
+            }
+            
+            if (date != null) {
+                metadata.takenDate = LocalDateTime.ofInstant(date.toInstant(), ZoneId.systemDefault());
+            }
+        }
+    }
+
+    private void extractGpsInfo(Metadata rawMetadata, ImageMetadata metadata) {
+        GpsDirectory gpsDirectory = rawMetadata.getFirstDirectoryOfType(GpsDirectory.class);
+        if (gpsDirectory != null) {
+            GeoLocation geoLocation = gpsDirectory.getGeoLocation();
+            if (geoLocation != null && !geoLocation.isZero()) {
+                metadata.latitude = geoLocation.getLatitude();
+                metadata.longitude = geoLocation.getLongitude();
+                metadata.location = "위도: " + metadata.latitude + ", 경도: " + metadata.longitude;
+            }
+        }
+    }
+
+    // 메타데이터 저장을 위한 내부 클래스
+    private static class ImageMetadata {
+        LocalDateTime takenDate;
+        String location;
+        Double latitude;
+        Double longitude;
+        
+        // 메타데이터가 완전한지 확인
+        public boolean isComplete() {
+            return takenDate != null && latitude != null && longitude != null;
+        }
+    }
+}

--- a/src/main/java/ssafy/retrip/aws/S3Uploader.java
+++ b/src/main/java/ssafy/retrip/aws/S3Uploader.java
@@ -1,0 +1,117 @@
+package ssafy.retrip.aws;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.http.urlconnection.UrlConnectionHttpClient;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Optional;
+import java.util.UUID;
+
+@Component
+public class S3Uploader {
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String dirName;
+
+    public S3Uploader(
+            @Value("${spring.cloud.aws.credentials.access-key}") String accessKey,
+            @Value("${spring.cloud.aws.credentials.secret-key}") String secretKey,
+            @Value("${spring.cloud.aws.region.static}") String region,
+            @Value("${spring.cloud.aws.s3.bucket}") String bucket,
+            @Value("${spring.cloud.aws.s3.dir-name}") String dirName) {
+        
+        this.bucket = bucket;
+        this.dirName = dirName;
+        
+        // 명시적으로 UrlConnectionHttpClient 지정
+        this.s3Client = S3Client.builder()
+                .httpClient(UrlConnectionHttpClient.builder().build())
+                .region(Region.of(region))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(accessKey, secretKey)))
+                .build();
+    }
+
+    public String upload(MultipartFile multipartFile, String dirName) throws IOException {
+        File uploadFile = convert(multipartFile)
+                .orElseThrow(() -> new IllegalArgumentException("MultipartFile -> File 변환 실패"));
+        
+        return upload(uploadFile, dirName);
+    }
+
+    private String upload(File uploadFile, String dirName) {
+        String fileName = dirName + "/" + UUID.randomUUID() + uploadFile.getName();
+        String uploadImageUrl = putS3(uploadFile, fileName);
+        
+        // 로컬에 생성된 파일 삭제
+        removeNewFile(uploadFile);
+        
+        return uploadImageUrl;
+    }
+
+    private String putS3(File uploadFile, String fileName) {
+        s3Client.putObject(PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(fileName)
+                .build(), 
+                RequestBody.fromFile(uploadFile));
+        
+        return s3Client.utilities().getUrl(builder -> builder.bucket(bucket).key(fileName)).toString();
+    }
+
+    private void removeNewFile(File targetFile) {
+        if (targetFile.delete()) {
+            System.out.println("파일이 삭제되었습니다.");
+        } else {
+            System.out.println("파일이 삭제되지 못했습니다.");
+        }
+    }
+
+    // 테스트를 위해 protected로 변경
+    public Optional<File> convert(MultipartFile file) throws IOException {
+        if (file == null || file.isEmpty()) {
+            return Optional.empty();
+        }
+
+        // 1. 원본 파일명 가져오기
+        String originalFilename = file.getOriginalFilename();
+        if (originalFilename == null || originalFilename.isBlank()) {
+            originalFilename = "unnamed-file";
+        }
+
+        // 2. 안전한 임시 파일 생성 (UUID 사용으로 중복 방지)
+        String fileExtension = originalFilename.contains(".")
+                ? originalFilename.substring(originalFilename.lastIndexOf("."))
+                : "";
+
+        File tempFile = File.createTempFile(
+                UUID.randomUUID().toString(),
+                fileExtension,
+                new File(System.getProperty("java.io.tmpdir"))
+        );
+
+        // 3. 파일 내용 쓰기
+        try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+            fos.write(file.getBytes());
+        } catch (IOException e) {
+            // 오류 발생 시 파일 삭제 시도
+            if (!tempFile.delete()) {
+                tempFile.deleteOnExit();
+            }
+            throw new IOException("파일 변환 중 오류 발생: " + e.getMessage(), e);
+        }
+
+        return Optional.of(tempFile);
+    }
+}

--- a/src/main/java/ssafy/retrip/config/WebConfig.java
+++ b/src/main/java/ssafy/retrip/config/WebConfig.java
@@ -1,0 +1,31 @@
+package ssafy.retrip.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.DefaultRedirectStrategy;
+import org.springframework.security.web.RedirectStrategy;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@EnableWebMvc
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    private String FRONT_SERVER = "http://localhost:5173";
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins(FRONT_SERVER)
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("Authorization")
+                .allowCredentials(true);
+    }
+
+    @Bean
+    public RedirectStrategy redirectStrategy() {
+        return new DefaultRedirectStrategy();
+    }
+}

--- a/src/main/java/ssafy/retrip/domain/image/Image.java
+++ b/src/main/java/ssafy/retrip/domain/image/Image.java
@@ -1,0 +1,46 @@
+package ssafy.retrip.domain.image;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssafy.retrip.domain.BaseEntity;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "images")
+public class Image extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String imageUrl;
+
+    @Column(nullable = false)
+    private String originalFileName;
+
+    @Column(nullable = false)
+    private String storedFileName;
+
+    private String contentType;
+
+    private Long fileSize;
+
+    private LocalDateTime takenDate;
+
+    private String location;
+
+    private Double latitude;
+
+    private Double longitude;
+    
+    private String dirName;
+}

--- a/src/main/java/ssafy/retrip/domain/image/ImageRepository.java
+++ b/src/main/java/ssafy/retrip/domain/image/ImageRepository.java
@@ -1,0 +1,18 @@
+package ssafy.retrip.domain.image;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface ImageRepository extends JpaRepository<Image, Long> {
+    
+    // 디렉토리명으로 이미지 찾기
+    List<Image> findByDirName(String dirName);
+    
+    // 위치 정보가 있는 이미지 찾기
+    List<Image> findByLatitudeIsNotNullAndLongitudeIsNotNull();
+    
+    // 촬영 날짜 기준으로 이미지 찾기
+    List<Image> findByTakenDateBetween(LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/ssafy/retrip/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/ssafy/retrip/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,47 @@
+package ssafy.retrip.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IOException.class)
+    public ResponseEntity<Map<String, String>> handleIOException(IOException e) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "파일 처리 중 오류가 발생했습니다.");
+        errorResponse.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, String>> handleIllegalArgumentException(IllegalArgumentException e) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "잘못된 요청입니다.");
+        errorResponse.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errorResponse);
+    }
+
+    @ExceptionHandler(MaxUploadSizeExceededException.class)
+    public ResponseEntity<Map<String, String>> handleMaxUploadSizeExceededException(MaxUploadSizeExceededException e) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "파일 크기 제한 초과");
+        errorResponse.put("message", "업로드 가능한 최대 파일 크기를 초과했습니다.");
+        return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE).body(errorResponse);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Map<String, String>> handleGenericException(Exception e) {
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "서버 오류가 발생했습니다.");
+        errorResponse.put("message", e.getMessage());
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body(errorResponse);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,13 +2,20 @@ spring:
   profiles:
     default: local
 
+  # 파일 업로드 설정
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 50MB
+
 ---
 spring:
   # Profile Config
   config:
     activate:
       on-profile: local
-
+    import:
+      - optional:file:.env
   datasource:
     driver-class-name: ${DB_DRIVER_CLASS_NAME}
     url: ${DB_URL}
@@ -20,7 +27,7 @@ spring:
     show-sql: true
     database: mysql
     hibernate:
-      ddl-auto: none
+      ddl-auto: create-drop
     properties:
       hibernate:
         format_sql: true
@@ -49,7 +56,18 @@ spring:
               - name                # 이름
               - profile_nickname    # 닉네임
               - account_email       # 이메일
-
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: retrip-photos-ssafy04
+        dir-name: images
+      stack:
+        auto: false
 ---
 spring:
   # Profile Config
@@ -98,3 +116,15 @@ spring:
               - name                # 이름
               - profile_nickname    # 닉네임
               - account_email       # 이메일
+  cloud:
+    aws:
+      credentials:
+        access-key: ${AWS_ACCESS_KEY_ID}
+        secret-key: ${AWS_SECRET_ACCESS_KEY}
+      region:
+        static: ap-northeast-2
+      s3:
+        bucket: retrip-photos-ssafy04
+        dir-name: test-images
+      stack:
+        auto: false

--- a/src/test/java/ssafy/retrip/domain/aws/S3UploaderTest.java
+++ b/src/test/java/ssafy/retrip/domain/aws/S3UploaderTest.java
@@ -1,0 +1,166 @@
+package ssafy.retrip.domain.aws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.S3Utilities;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import ssafy.retrip.aws.S3Uploader;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+public class S3UploaderTest {
+
+    @Mock
+    private S3Client s3Client;
+
+    @Mock
+    private S3Utilities s3Utilities;
+
+    private S3Uploader s3Uploader;
+    private S3Uploader spyUploader;
+
+    private final String BUCKET_NAME = "retrip-photos-ssafy04";
+    private final String DIR_NAME = "test-images";
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        
+        // S3Uploader 생성자 파라미터 설정
+        s3Uploader = new S3Uploader(
+                "test-access-key",
+                "test-secret-key",
+                "ap-northeast-2",
+                BUCKET_NAME,
+                DIR_NAME
+        );
+        
+        // private 필드 s3Client를 mock 객체로 교체
+        ReflectionTestUtils.setField(s3Uploader, "s3Client", s3Client);
+        
+        // mock S3Client가 S3Utilities를 반환하도록 설정 (lenient 모드)
+        lenient().when(s3Client.utilities()).thenReturn(s3Utilities);
+        
+        // 테스트용 스파이 객체 생성 (부분 모킹)
+        spyUploader = spy(s3Uploader);
+    }
+
+    @Test
+    void uploadFileSuccess() throws IOException {
+        // Given
+        String fileName = "test-image.jpg";
+        String fileContent = "fake image content";
+        
+        MultipartFile multipartFile = new MockMultipartFile(
+                fileName,
+                fileName,
+                "image/jpeg",
+                fileContent.getBytes(StandardCharsets.UTF_8)
+        );
+        
+        // S3 업로드 성공 모킹
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        
+        // S3 URL 모킹
+        URL mockUrl = new URL("https://retrip-photos-ssafy04.s3.amazonaws.com/test-images/test-image.jpg");
+        when(s3Utilities.getUrl(any(Consumer.class))).thenReturn(mockUrl);
+        
+        // When
+        String result = s3Uploader.upload(multipartFile, DIR_NAME);
+        
+        // Then
+        assertNotNull(result);
+        assertTrue(result.contains("https://"));
+        assertTrue(result.contains(BUCKET_NAME));
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        verify(s3Client, times(1)).utilities();
+        verify(s3Utilities, times(1)).getUrl(any(Consumer.class));
+    }
+
+    @Test
+    void uploadFileWithEmptyFile() throws IOException {
+        // Given
+        MultipartFile emptyFile = new MockMultipartFile(
+                "empty.jpg",
+                "empty.jpg",
+                "image/jpeg",
+                new byte[0]
+        );
+        
+        // 파일 변환 단계에서 빈 Optional을 반환하도록 spy 설정
+        doReturn(Optional.empty()).when(spyUploader).convert(any(MultipartFile.class));
+        
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            spyUploader.upload(emptyFile, DIR_NAME);
+        });
+        
+        // 실제로 S3 관련 메서드가 호출되지 않음을 검증
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        verify(s3Client, never()).utilities();
+    }
+
+    @Test
+    void uploadFileWithNullFile() {
+        // When & Then
+        assertThrows(IllegalArgumentException.class, () -> {
+            s3Uploader.upload(null, DIR_NAME);
+        });
+        
+        // 실제로 S3 관련 메서드가 호출되지 않음을 검증
+        verify(s3Client, never()).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        verify(s3Client, never()).utilities();
+    }
+
+    @Test
+    void uploadLargeFile() throws IOException {
+        // Given
+        byte[] largeContent = new byte[2 * 1024 * 1024]; // 2MB
+        MultipartFile largeFile = new MockMultipartFile(
+                "large.jpg",
+                "large.jpg",
+                "image/jpeg",
+                largeContent
+        );
+        
+        // S3 업로드 성공 모킹
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+        
+        // S3 URL 모킹
+        URL mockUrl = new URL("https://retrip-photos-ssafy04.s3.amazonaws.com/test-images/large.jpg");
+        when(s3Utilities.getUrl(any(Consumer.class))).thenReturn(mockUrl);
+        
+        // When
+        String result = s3Uploader.upload(largeFile, DIR_NAME);
+        
+        // Then
+        assertNotNull(result);
+        assertTrue(result.contains("https://"));
+        verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+        verify(s3Client, times(1)).utilities();
+        verify(s3Utilities, times(1)).getUrl(any(Consumer.class));
+    }
+
+}

--- a/src/test/java/ssafy/retrip/domain/member/MemberTest.java
+++ b/src/test/java/ssafy/retrip/domain/member/MemberTest.java
@@ -27,8 +27,8 @@ class MemberTest {
 
     // then
     assertThat(savedMember.getId()).isNotNull();
-    assertThat(savedMember).extracting("kakaoId", "nickname", "profileImageUrl")
-        .containsExactly("1234567890", "nickname", "http://localhost:8080");
+    assertThat(savedMember).extracting("kakaoId", "nickname", "email")
+        .containsExactly("1234567890", "nickname", "1234@naver.com");
   }
 
   private Member createMember() {
@@ -36,6 +36,6 @@ class MemberTest {
     return Member.builder()
         .kakaoId("1234567890")
         .nickname("nickname")
-        .profileImageUrl("http://localhost:8080").build();
+        .email("1234@naver.com").build();
   }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#6

## 📝 작업 내용

AWS S3 연동과 이미지 업로드 시 메타데이터를 추출하는 기능을 구현했습니다.

여러개의 이미지를 받아서 ImageService 에서 로컬에 임시로 저장한 후, 메타데이터를 추출합니다. 메타데이터가 정상적으로 추출되면, S3에 업로드하고, DB에도 메타데이터 정보와 함께 저장합니다.

<br/>

## 💬 리뷰 요구사항
> 이미지 메타데이터 추출 실패시 어떻게 처리할지 논의가 필요합니다.

<br/>

