### PR TITLE
Feat: 로그인 이후 세션 방식으로 인증 유지 로직 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     testImplementation 'org.springframework.security:spring-security-test'
 
+    // Apache StringUtils
+    implementation 'org.apache.commons:commons-lang3:3.17.0'
+
     // OAuth2 Client
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 

--- a/src/main/java/ssafy/retrip/domain/member/Member.java
+++ b/src/main/java/ssafy/retrip/domain/member/Member.java
@@ -2,7 +2,10 @@ package ssafy.retrip.domain.member;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.io.Serial;
+import java.io.Serializable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,10 +15,13 @@ import ssafy.retrip.domain.BaseEntity;
 @Getter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member extends BaseEntity {
+public class Member extends BaseEntity implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
 
   @Id
-  @GeneratedValue(strategy = jakarta.persistence.GenerationType.IDENTITY)
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
   private String kakaoId;

--- a/src/main/java/ssafy/retrip/filter/SessionAuthenticationFilter.java
+++ b/src/main/java/ssafy/retrip/filter/SessionAuthenticationFilter.java
@@ -1,0 +1,33 @@
+package ssafy.retrip.filter;
+
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class SessionAuthenticationFilter extends OncePerRequestFilter {
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+      FilterChain filterChain) throws ServletException, IOException {
+
+    HttpSession session = request.getSession();
+    String kakaoId = (String) session.getAttribute("member");
+
+    if (isEmpty(kakaoId)) {
+      response.sendRedirect("/login");
+      return;
+    }
+
+    filterChain.doFilter(request, response);
+  }
+}

--- a/src/main/java/ssafy/retrip/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/ssafy/retrip/handler/OAuth2AuthenticationFailureHandler.java
@@ -6,17 +6,18 @@ import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
+@RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
 
-  private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
+  private final RedirectStrategy redirectStrategy;
 
   private static final String REDIRECT_URL = "/login/callback";
   private static final String FRONT_SERVER = "http://localhost:5173";
@@ -36,6 +37,5 @@ public class OAuth2AuthenticationFailureHandler implements AuthenticationFailure
         .fromUriString(FRONT_SERVER + REDIRECT_URL)
         .queryParam("error", errorMessage)
         .build().toUriString();
-
   }
 }

--- a/src/main/java/ssafy/retrip/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/ssafy/retrip/handler/OAuth2AuthenticationSuccessHandler.java
@@ -3,15 +3,13 @@ package ssafy.retrip.handler;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import java.io.IOException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.oidc.user.OidcUser;
-import org.springframework.security.web.DefaultRedirectStrategy;
 import org.springframework.security.web.RedirectStrategy;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
-import org.springframework.security.web.savedrequest.HttpSessionRequestCache;
-import org.springframework.security.web.savedrequest.RequestCache;
 import org.springframework.stereotype.Component;
 import ssafy.retrip.domain.member.Member;
 import ssafy.retrip.domain.member.MemberRepository;
@@ -20,11 +18,11 @@ import ssafy.retrip.domain.member.MemberRepository;
 @RequiredArgsConstructor
 public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
 
-  private final RequestCache requestCache = new HttpSessionRequestCache();
-  private final RedirectStrategy redirectStrategy = new DefaultRedirectStrategy();
   private final MemberRepository memberRepository;
+  private final RedirectStrategy redirectStrategy;
 
   private static final String REDIRECT_URL = "/";
+  private static final String SESSION_MEMBER_KEY = "member";
 
   @Override
   public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
@@ -33,6 +31,9 @@ public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccess
     OidcUser oidcUser = (OidcUser) authentication.getPrincipal();
 
     Member member = findMember(oidcUser);
+
+    HttpSession session = request.getSession();
+    session.setAttribute(SESSION_MEMBER_KEY, member.getKakaoId());
 
     redirectStrategy.sendRedirect(request, response, REDIRECT_URL);
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -50,6 +50,11 @@ spring:
               - profile_nickname    # 닉네임
               - account_email       # 이메일
 
+server:
+  servlet:
+    session:
+      timeout: 60m
+
 ---
 spring:
   # Profile Config
@@ -98,3 +103,8 @@ spring:
               - name                # 이름
               - profile_nickname    # 닉네임
               - account_email       # 이메일
+
+server:
+  servlet:
+    session:
+      timeout: 60m

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,14 +8,18 @@ spring:
       max-file-size: 10MB
       max-request-size: 50MB
 
+server:
+  servlet:
+    session:
+      timeout: 60m
+
 ---
 spring:
   # Profile Config
   config:
     activate:
       on-profile: local
-    import:
-      - optional:file:.env
+
   datasource:
     driver-class-name: ${DB_DRIVER_CLASS_NAME}
     url: ${DB_URL}
@@ -27,7 +31,7 @@ spring:
     show-sql: true
     database: mysql
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: none
     properties:
       hibernate:
         format_sql: true
@@ -57,10 +61,6 @@ spring:
               - profile_nickname    # 닉네임
               - account_email       # 이메일
 
-server:
-  servlet:
-    session:
-      timeout: 60m
 
   cloud:
     aws:
@@ -123,11 +123,6 @@ spring:
               - name                # 이름
               - profile_nickname    # 닉네임
               - account_email       # 이메일
-
-server:
-  servlet:
-    session:
-      timeout: 60m
 
   cloud:
     aws:

--- a/src/test/java/ssafy/retrip/handler/OAuth2AuthenticationFailureHandlerTest.java
+++ b/src/test/java/ssafy/retrip/handler/OAuth2AuthenticationFailureHandlerTest.java
@@ -1,0 +1,52 @@
+package ssafy.retrip.handler;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.mockito.BDDMockito.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.verify;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.RedirectStrategy;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationFailureHandlerTest {
+
+  @Mock
+  private RedirectStrategy redirectStrategy;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  AuthenticationException exception;
+
+  @InjectMocks
+  private OAuth2AuthenticationFailureHandler handler;
+
+  @Test
+  @DisplayName("로그인 실패 시 에러 메시지를 포함한 URL로 리다이렉트한다.")
+  void failureHandlerRedirectsWithErrorMessage() throws Exception {
+    // given
+    String errorMessage = "인증 실패";
+    String encodedError = URLEncoder.encode(errorMessage, UTF_8);
+    String expectedUrl = "http://localhost:5173/login/callback?error=" + encodedError;
+    given(exception.getMessage()).willReturn(errorMessage);
+
+    // when
+    handler.onAuthenticationFailure(request, response, exception);
+    // then
+    verify(redirectStrategy).sendRedirect(eq(request), eq(response), eq(expectedUrl));
+  }
+}

--- a/src/test/java/ssafy/retrip/handler/OAuth2AuthenticationSuccessHandlerTest.java
+++ b/src/test/java/ssafy/retrip/handler/OAuth2AuthenticationSuccessHandlerTest.java
@@ -1,0 +1,110 @@
+package ssafy.retrip.handler;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.RedirectStrategy;
+import ssafy.retrip.domain.member.Member;
+import ssafy.retrip.domain.member.MemberRepository;
+
+@ExtendWith(MockitoExtension.class)
+class OAuth2AuthenticationSuccessHandlerTest {
+
+  @Mock
+  private MemberRepository memberRepository;
+
+  @Mock
+  private RedirectStrategy redirectStrategy;
+
+  @Mock
+  private OidcUser oidcUser;
+
+  @Mock
+  private HttpSession session;
+
+  @Mock
+  private HttpServletRequest request;
+
+  @Mock
+  private HttpServletResponse response;
+
+  @Mock
+  private Authentication authentication;
+
+  @InjectMocks
+  private OAuth2AuthenticationSuccessHandler handler;
+
+  private final String REDIRECT_URL = "/";
+  private final String kakaoId = "1234567890";
+  private final String email = "test@email.com";
+  private final String nickname = "tester";
+
+  @Test
+  @DisplayName("회원이 존재하면 세션에 저장하고 리다이렉트한다.")
+  void existMemberSuccessHandlerTest() throws Exception {
+
+    // given
+    Member member = createMember();
+
+    given(oidcUser.getSubject()).willReturn(kakaoId);
+    given(oidcUser.getEmail()).willReturn(email);
+    given(oidcUser.getAttribute("nickname")).willReturn(nickname);
+    given(memberRepository.findByKakaoId(kakaoId)).willReturn(Optional.of(member));
+    given(authentication.getPrincipal()).willReturn(oidcUser);
+    given(request.getSession()).willReturn(session);
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(memberRepository).findByKakaoId(kakaoId);
+    verify(session).setAttribute("member", kakaoId);
+    verify(redirectStrategy).sendRedirect(request, response, REDIRECT_URL);
+    verifyNoMoreInteractions(redirectStrategy);
+  }
+
+  @Test
+  @DisplayName("회원이 존재하지 않으면 회원을 생성하고 세션에 저장한 후 리다이렉트한다.")
+  void notExistMemberSuccessHandler() throws Exception {
+
+    // given
+    Member newMember = createMember();
+
+    given(oidcUser.getSubject()).willReturn(kakaoId);
+    given(oidcUser.getEmail()).willReturn(email);
+    given(oidcUser.getAttribute("nickname")).willReturn(nickname);
+    given(memberRepository.findByKakaoId(kakaoId)).willReturn(Optional.empty());
+    given(memberRepository.save(any(Member.class))).willReturn(newMember);
+    given(authentication.getPrincipal()).willReturn(oidcUser);
+    given(request.getSession()).willReturn(session);
+
+    // when
+    handler.onAuthenticationSuccess(request, response, authentication);
+
+    // then
+    verify(memberRepository).save(any(Member.class));
+    verify(session).setAttribute("member", kakaoId);
+    verify(redirectStrategy).sendRedirect(request, response, REDIRECT_URL);
+  }
+
+  private Member createMember() {
+    return Member.builder()
+        .kakaoId(this.kakaoId)
+        .email(this.email)
+        .nickname(this.nickname).build();
+  }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#3 

## 📝 작업 내용

- 회원 로그인이 완료되었을 때, 세션 방식을 활용하여 인증 환경을 유지하는 기능을 구현했습니다.
- 세션 유지 기간을 60분으로 설정하였습니다.
- 로그인 여부를 확인하는 SessionAuthenticationFilter 기능을 구현했습니다. 

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

추후 Argument Resolver 기능을 도입하여 회원/비회원 분기를 시킬 예정입니다.
그 이전까지 Handling, Filtering 로직 관련 설정에 대해서 검토해주시면 감사하겠습니다.
Handler 테스트를 위해서 보다 더 깔끔하게 Mock 테스트 하기 위해서 RedirectStrategy 객체를 Bean으로 관리하도록 구현했습니다. 
이에 대해서 검토해주세요.
<br/>