### PR TITLE
feat: 이미지 업로드 후 메타데이터를 추출해서 ReTrip을 생성기능 추가

### DIFF
--- a/src/main/java/ssafy/retrip/api/service/image/ImageService.java
+++ b/src/main/java/ssafy/retrip/api/service/image/ImageService.java
@@ -266,7 +266,6 @@ public class ImageService {
                 // 중요: EXIF의 시간은 이미 로컬 시간이므로 시스템 기본 시간대로 변환하지 않음
                 // ZoneId.systemDefault() 대신 ZoneId.of("UTC")를 사용하여 시간대 변환 문제 방지
                 metadata.takenDate = LocalDateTime.ofInstant(date.toInstant(), ZoneId.of("UTC"));
-                log.info("추출된 촬영 시간(UTC 기준): {}", metadata.takenDate);
             }
         }
     }

--- a/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
@@ -1,0 +1,278 @@
+package ssafy.retrip.api.service.retrip;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssafy.retrip.api.controller.image.response.ImageResponseDto;
+import ssafy.retrip.domain.image.Image;
+import ssafy.retrip.domain.retrip.Retrip;
+import ssafy.retrip.domain.retrip.RetripRepository;
+import ssafy.retrip.domain.retrip.TimeSlot;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.*;
+import java.util.stream.Collectors;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RetripService {
+    private final RetripRepository retripRepository;
+
+    // yml 설정에서 값 주입
+    @Value("${retrip.image.min-count}")
+    private int minImages;
+
+    @Value("${retrip.image.max-count}")
+    private int maxImages;
+
+    // 다른 서비스에서 호출 가능하도록 public으로 변경
+    @Transactional
+    public Retrip createRetrip(List<Image> images, String dirName) {
+        // 이미지 개수 검증
+        if (images == null || images.size() < minImages) {
+            throw new IllegalArgumentException("Retrip 생성을 위해서는 최소 " + minImages + "장의 이미지가 필요합니다.");
+        }
+
+        if (images.size() > maxImages) {
+            log.warn("이미지가 {}장을 초과했습니다. 처음 {}장만 처리합니다.", maxImages, maxImages);
+            images = images.subList(0, maxImages);
+        }
+
+        // 1. 이미지들의 시간 정렬 (여행 시작/종료 시간 결정)
+        images.sort(Comparator.comparing(Image::getTakenDate));
+        LocalDateTime startDate = images.get(0).getTakenDate();
+        LocalDateTime endDate = images.get(images.size() - 1).getTakenDate();
+
+        // 디버깅을 위한 로그 추가
+        log.info("이미지 시간대 분석 시작 - 총 이미지 수: {}", images.size());
+        for (int i = 0; i < Math.min(10, images.size()); i++) {
+            LocalDateTime takenDate = images.get(i).getTakenDate();
+            TimeSlot slot = TimeSlot.from(takenDate);
+            log.info("이미지 {}: 시간={}, 시간대={} ({})", 
+                     i, 
+                     takenDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                     slot,
+                     slot.getTimeRange());
+        }
+
+        // 2. 총 이동거리 계산
+        double totalDistance = calculateTotalDistance(images);
+
+        // 3. 주요 시간대 분석 (원본 시간 사용)
+        TimeSlot mainTimeSlot = analyzeMainTimeSlot(images);
+        log.info("주요 시간대: {} ({})", mainTimeSlot, mainTimeSlot.getTimeRange());
+
+        // 4. 가장 많이 촬영한 장소 분석
+        Map<String, Object> mainLocationInfo = analyzeMainLocation(images);
+        String mainLocation = (String) mainLocationInfo.get("name");
+        Double mainLocationLat = (Double) mainLocationInfo.get("latitude");
+        Double mainLocationLng = (Double) mainLocationInfo.get("longitude");
+
+        // 5. Retrip 엔티티 생성
+        Retrip retrip = Retrip.builder()
+                .totalDistance(totalDistance)
+                .mainTimeSlot(mainTimeSlot)
+                .mainLocation(mainLocation)
+                .mainLocationLat(mainLocationLat)
+                .mainLocationLng(mainLocationLng)
+                .startDate(startDate)
+                .endDate(endDate)
+                .imageCount(images.size())
+                .name(generateTripName(dirName, startDate))
+                .description("이 여행에서는 " + mainLocation + "에서 가장 많은 사진을 찍었으며, " +
+                        "주로 " + mainTimeSlot.getDescription() + "에 활동했습니다. " +
+                        "총 이동거리는 " + String.format("%.2f", totalDistance) + "km입니다.")
+                .build();
+
+        // 6. Image와 Retrip 연결 (개선된 1:N 관계 활용)
+        retrip.addImages(images);
+
+        // 7. Retrip 저장
+        return retripRepository.save(retrip);
+    }
+
+    // 간소화된 시간대 분석 메서드 - 원본 시간 기준
+    private TimeSlot analyzeMainTimeSlot(List<Image> images) {
+        Map<TimeSlot, Integer> timeSlotCounts = new EnumMap<>(TimeSlot.class);
+        
+        // 각 시간대별 카운트 초기화
+        for (TimeSlot slot : TimeSlot.values()) {
+            timeSlotCounts.put(slot, 0);
+        }
+
+        int processedImages = 0;
+        int nullTimeImages = 0;
+        
+        // 각 이미지에 대해 시간대 분석
+        for (Image image : images) {
+            LocalDateTime takenDate = image.getTakenDate();
+            if (takenDate != null) {
+                // 원본 시간을 기준으로 TimeSlot 결정
+                TimeSlot slot = TimeSlot.from(takenDate);
+                timeSlotCounts.put(slot, timeSlotCounts.get(slot) + 1);
+                processedImages++;
+                
+                // 디버깅을 위한 로그 추가 (최초 10개 이미지만)
+                if (processedImages <= 10) {
+                    log.info("이미지 {}: 시간={}, 시간대={}", 
+                          processedImages - 1, 
+                          takenDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss")),
+                          slot);
+                }
+            } else {
+                nullTimeImages++;
+            }
+        }
+        
+        // 디버깅을 위한 시간대별 카운트 로그
+        log.info("시간대별 이미지 카운트 - 처리된 이미지: {}, 시간 정보 없음: {}", processedImages, nullTimeImages);
+        for (TimeSlot slot : TimeSlot.values()) {
+            log.info("시간대 {}: {} 장", slot, timeSlotCounts.get(slot));
+        }
+
+        // 모든 이미지에 시간 정보가 없는 경우 기본값 반환
+        if (processedImages == 0) {
+            log.warn("시간 정보가 있는 이미지가 없습니다. 기본 시간대(AFTERNOON)를 사용합니다.");
+            return TimeSlot.AFTERNOON;
+        }
+
+        // 가장 많은 이미지가 속한 시간대 찾기
+        TimeSlot mainSlot = timeSlotCounts.entrySet()
+                .stream()
+                .max(Map.Entry.comparingByValue())
+                .map(Map.Entry::getKey)
+                .orElse(TimeSlot.AFTERNOON);
+                
+        log.info("선택된 주요 시간대: {} (이미지 {}장)", mainSlot, timeSlotCounts.get(mainSlot));
+        return mainSlot;
+    }
+
+    //TODO CHATGPT API를 사용하여 해당 위도와 경도가 어디에서 찍은 사진인지 판단하고 name을 받아오게
+    private String getLocationName(double latitude, double longitude) {
+        // 여기서는 단순히 좌표를 문자열로 반환
+        // TO-DO CHATGPT API를 사용하여 해당 위도와 경도가 어디에서 찍은 사진인지 판단하고 name을 받아오게
+        return String.format("위도 %.4f, 경도 %.4f 부근", latitude, longitude);
+    }
+
+    //TODO CHATGPT API를 사용하여 해당 여행의 이름 생성(비전 API 사용)
+    private String generateTripName(String dirName, LocalDateTime startDate) {
+        String dateStr = startDate.format(DateTimeFormatter.ofPattern("yyyy년 MM월 dd일"));
+
+        if (dirName != null && !dirName.isEmpty()) {
+            return dirName + " 여행 - " + dateStr;
+        } else {
+            return "여행 - " + dateStr;
+        }
+    }
+
+    // Haversine 공식을 사용한 두 좌표 간 거리 계산 (km)
+    private double calculateDistance(double lat1, double lon1, double lat2, double lon2) {
+        final int R = 6371; // 지구 반지름 (km)
+        double dLat = Math.toRadians(lat2 - lat1);
+        double dLon = Math.toRadians(lon2 - lon1);
+        double a = Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+                Math.cos(Math.toRadians(lat1)) * Math.cos(Math.toRadians(lat2)) *
+                        Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        double c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+        return R * c;
+    }
+
+    // 이미지들의 총 이동거리 계산
+    private double calculateTotalDistance(List<Image> images) {
+        double totalDistance = 0.0;
+
+        // 시간순으로 정렬
+        images.sort(Comparator.comparing(Image::getTakenDate));
+
+        for (int i = 0; i < images.size() - 1; i++) {
+            Image current = images.get(i);
+            Image next = images.get(i + 1);
+
+            // 두 이미지 모두 위치 정보가 있는 경우에만 계산
+            if (current.getLatitude() != null && current.getLongitude() != null &&
+                    next.getLatitude() != null && next.getLongitude() != null) {
+
+                double distance = calculateDistance(
+                        current.getLatitude(), current.getLongitude(),
+                        next.getLatitude(), next.getLongitude()
+                );
+
+                totalDistance += distance;
+            }
+        }
+
+        return totalDistance;
+    }
+
+    // 장소 클러스터링 - 가장 많이 촬영한 위치 분석
+    private Map<String, Object> analyzeMainLocation(List<Image> images) {
+        // 위치 정보가 있는 이미지만 필터링
+        List<Image> imagesWithLocation = images.stream()
+                .filter(img -> img.getLatitude() != null && img.getLongitude() != null)
+                .collect(Collectors.toList());
+
+        // 위치 정보가 없으면 기본값 반환
+        if (imagesWithLocation.isEmpty()) {
+            Map<String, Object> defaultLocation = new HashMap<>();
+            defaultLocation.put("name", "알 수 없는 위치");
+            defaultLocation.put("latitude", null);
+            defaultLocation.put("longitude", null);
+            return defaultLocation;
+        }
+
+        // 클러스터링 (0.1km 이내는 같은 장소로 간주)
+        final double CLUSTER_THRESHOLD = 0.1;
+        List<List<Image>> clusters = new ArrayList<>();
+
+        for (Image image : imagesWithLocation) {
+            boolean addedToCluster = false;
+
+            for (List<Image> cluster : clusters) {
+                Image representative = cluster.get(0);
+                double distance = calculateDistance(
+                        representative.getLatitude(), representative.getLongitude(),
+                        image.getLatitude(), image.getLongitude()
+                );
+
+                if (distance <= CLUSTER_THRESHOLD) {
+                    cluster.add(image);
+                    addedToCluster = true;
+                    break;
+                }
+            }
+
+            if (!addedToCluster) {
+                List<Image> newCluster = new ArrayList<>();
+                newCluster.add(image);
+                clusters.add(newCluster);
+            }
+        }
+
+        // 가장 큰 클러스터 찾기
+        List<Image> largestCluster = clusters.stream()
+                .max(Comparator.comparingInt(List::size))
+                .orElse(List.of(imagesWithLocation.get(0)));
+
+        // 클러스터의 대표 위치 계산 (평균)
+        double sumLat = 0, sumLng = 0;
+        for (Image img : largestCluster) {
+            sumLat += img.getLatitude();
+            sumLng += img.getLongitude();
+        }
+        double avgLat = sumLat / largestCluster.size();
+        double avgLng = sumLng / largestCluster.size();
+
+        // 결과 반환
+        Map<String, Object> result = new HashMap<>();
+        result.put("name", getLocationName(avgLat, avgLng));
+        result.put("latitude", avgLat);
+        result.put("longitude", avgLng);
+
+        return result;
+    }
+}

--- a/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
@@ -186,9 +186,6 @@ public class RetripService {
     private double calculateTotalDistance(List<Image> images) {
         double totalDistance = 0.0;
 
-        // 시간순으로 정렬
-        images.sort(Comparator.comparing(Image::getTakenDate));
-
         for (int i = 0; i < images.size() - 1; i++) {
             Image current = images.get(i);
             Image next = images.get(i + 1);

--- a/src/main/java/ssafy/retrip/domain/image/Image.java
+++ b/src/main/java/ssafy/retrip/domain/image/Image.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import ssafy.retrip.domain.BaseEntity;
+import ssafy.retrip.domain.retrip.Retrip;
 
 import java.time.LocalDateTime;
 
@@ -43,4 +44,31 @@ public class Image extends BaseEntity {
     private Double longitude;
     
     private String dirName;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "retrip_id")
+    private Retrip retrip;
+
+    /**
+     * Retrip 연관관계 설정 메서드 (개선된 양방향 관계 설정)
+     * @param retrip 연결할 Retrip 객체
+     */
+    public void setRetrip(Retrip retrip) {
+        // 자기 자신과의 비교를 통해 이미 같은 retrip이라면 작업 중단 (무한 루프 방지)
+        if (this.retrip == retrip) {
+            return;
+        }
+        
+        // 기존 연결이 있으면 제거
+        if (this.retrip != null) {
+            this.retrip.getImages().remove(this);
+        }
+        
+        this.retrip = retrip;
+        
+        // 새 연결 추가 (retrip이 null이 아니고, retrip의 이미지 리스트에 현재 이미지가 없는 경우)
+        if (retrip != null && !retrip.getImages().contains(this)) {
+            retrip.getImages().add(this);
+        }
+    }
 }

--- a/src/main/java/ssafy/retrip/domain/retrip/Retrip.java
+++ b/src/main/java/ssafy/retrip/domain/retrip/Retrip.java
@@ -1,0 +1,99 @@
+package ssafy.retrip.domain.retrip;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssafy.retrip.domain.BaseEntity;
+import ssafy.retrip.domain.image.Image;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "retrips")
+public class Retrip extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 여행 총 이동거리 (킬로미터)
+    private Double totalDistance;
+
+    // 주요 촬영 시간대
+    @Enumerated(EnumType.STRING)
+    private TimeSlot mainTimeSlot;
+
+    // 가장 많은 사진 촬영 장소
+    private String mainLocation;
+
+    // 가장 많은 사진 촬영 장소 좌표
+    private Double mainLocationLat;
+    private Double mainLocationLng;
+
+    // 여행 시작/종료 시간
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+
+    // 총 이미지 개수
+    private Integer imageCount;
+
+    // 여행 설명 (ChatGPT API로 생성 가능)
+    private String description;
+
+    // 여행 이름
+    private String name;
+
+    // Image와의 관계 설정 (양방향)
+    @OneToMany(mappedBy = "retrip", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Image> images = new ArrayList<>();
+    
+    /**
+     * 이미지 추가 메서드 (1:N 관계 설정을 위한 편의 메서드)
+     * @param image 추가할 이미지
+     */
+    public void addImage(Image image) {
+        // 이미 존재하는지 확인 (중복 추가 방지)
+        if (this.images.contains(image)) {
+            return;
+        }
+        
+        this.images.add(image);
+        if (image.getRetrip() != this) {
+            image.setRetrip(this);
+        }
+    }
+    
+    /**
+     * 이미지 다수 추가 메서드
+     * @param images 추가할 이미지 목록
+     */
+    public void addImages(List<Image> images) {
+        if (images != null) {
+            images.forEach(this::addImage);
+        }
+    }
+    
+    /**
+     * 이미지 제거 메서드
+     * @param image 제거할 이미지
+     */
+    public void removeImage(Image image) {
+        if (!this.images.contains(image)) {
+            return;
+        }
+        
+        this.images.remove(image);
+        if (image.getRetrip() == this) {
+            image.setRetrip(null);
+        }
+    }
+}

--- a/src/main/java/ssafy/retrip/domain/retrip/RetripRepository.java
+++ b/src/main/java/ssafy/retrip/domain/retrip/RetripRepository.java
@@ -1,0 +1,10 @@
+package ssafy.retrip.domain.retrip;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RetripRepository extends JpaRepository<Retrip, Long> {
+    // 기본 CRUD 메서드는 JpaRepository에서 제공됨
+    // 필요한 추가 쿼리 메서드는 여기에 정의
+}

--- a/src/main/java/ssafy/retrip/domain/retrip/TimeSlot.java
+++ b/src/main/java/ssafy/retrip/domain/retrip/TimeSlot.java
@@ -1,0 +1,77 @@
+package ssafy.retrip.domain.retrip;
+
+import java.time.LocalDateTime;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public enum TimeSlot {
+    DAWN(0, 5, "새벽(00:00-06:00)"),
+    MORNING(6, 11, "오전(06:00-12:00)"),
+    AFTERNOON(12, 17, "오후(12:00-18:00)"),
+    NIGHT(18, 23, "밤(18:00-24:00)");
+
+    private final int startHour;
+    private final int endHour;
+    private final String description;
+
+    TimeSlot(int startHour, int endHour, String description) {
+        this.startHour = startHour;
+        this.endHour = endHour;
+        this.description = description;
+    }
+
+    /**
+     * 주어진 시간이 이 시간대에 속하는지 확인
+     */
+    public boolean contains(LocalDateTime dateTime) {
+        int hour = dateTime.getHour();
+        return hour >= startHour && hour <= endHour;
+    }
+
+    /**
+     * 주어진 시간에 해당하는 시간대 반환
+     */
+    public static TimeSlot from(LocalDateTime dateTime) {
+        if (dateTime == null) {
+            log.warn("시간 정보가 없습니다. 기본 시간대(AFTERNOON)를 사용합니다.");
+            return AFTERNOON;
+        }
+        
+        int hour = dateTime.getHour();
+        return fromHour(hour);
+    }
+    
+    /**
+     * 시간값(0-23)을 기준으로 TimeSlot 반환
+     */
+    private static TimeSlot fromHour(int hour) {
+        if (hour < 0 || hour > 23) {
+            log.warn("비정상적인 시간값: {}. 범위(0-23)를 벗어났습니다. 기본값 AFTERNOON 사용.", hour);
+            return AFTERNOON;
+        }
+        
+        for (TimeSlot slot : values()) {
+            if (hour >= slot.startHour && hour <= slot.endHour) {
+                return slot;
+            }
+        }
+        
+        // 기본값으로 AFTERNOON 반환 (비정상 케이스)
+        log.error("시간대 결정 로직 오류. 시간값 {}에 해당하는 시간대를 찾지 못했습니다.", hour);
+        return AFTERNOON;
+    }
+
+    /**
+     * 시간대에 대한 설명 반환
+     */
+    public String getDescription() {
+        return description;
+    }
+    
+    /**
+     * 디버깅용 시간 정보 출력
+     */
+    public String getTimeRange() {
+        return String.format("%02d:00-%02d:59", startHour, endHour);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,6 +8,12 @@ spring:
       max-file-size: 10MB
       max-request-size: 50MB
 
+# ReTrip 애플리케이션 설정
+retrip:
+  image:
+    min-count: 5
+    max-count: 30
+
 ---
 spring:
   # Profile Config
@@ -128,3 +134,4 @@ spring:
         dir-name: test-images
       stack:
         auto: false
+


### PR DESCRIPTION
## #️⃣ 연관된 이슈



## 📝 작업 내용

- 이미지를 업로드 하고 5~30장의 이미지를 분석하여 Retrip 정보를 생성합니다.
- 현재 완성된 ReTrip 정보는 다음과 같습니다
- 1. 이미지 좌표값을 기반으로한 각 거리를 정렬 후 여행에서의 총 이동거리
- 2. 이미지 좌표값을 군집화하여 가장 많은 카운트가 된 클러스터를 가장 사진을 많이 찍은 여행지로 선정 -> 횟수와 평균 좌표값을 저장합니다 -> 좌표값을 추후 ChatGPT를 활용하여 어떤 여행지에 방문했는지 추측하여 저장할 예정입니다.
- 3. 이미지의 사진찍힌 시간을 토대로 여행의 시작과 끝 시간을 계산합니다.
- 4. 이미지의 사진의 시간정보를 바탕으로 어떤 시간대에 가장 많은 사진을 찍었는지 기록합니다.
- 추후 ReTrip 테이블을 기반으로 유저에게 보여질 정보를 구성할 예정입니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

