### PR TITLE
Fix: 비밀번호 변경 시 JPA 더티체킹이 이루어지지 않는 오류 수정

### DIFF
--- a/src/main/java/ssafy/retrip/api/service/member/MemberService.java
+++ b/src/main/java/ssafy/retrip/api/service/member/MemberService.java
@@ -81,6 +81,7 @@ public class MemberService {
     }
   }
 
+  @Transactional
   public void resetPassword(PasswordResetServiceRequest request) {
     Member member = memberRepository.findByEmail(request.getEmail()).orElseThrow(
         () -> new IllegalArgumentException("존재하지 않는 회원입니다.")


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#12 

## 📝 작업 내용

- @Transactional(readOnly = true) 어노테이션을 전역으로 설정해서 비밀번호 수정을 위한 더티체킹을 하지 않는 현상이 발생했습니다.
- 비밀번호를 수정하는 메서드에 별도로 @Transactional 어노테이션을 추가하여 우선적으로 적용되도록 수정하였습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

