### PR TITLE
Refactor: ReTrip 프롬포트 변경으로 인한 ReTrip Entity 및 Response DTO 필드 변수 수정

### DIFF
--- a/src/main/java/ssafy/retrip/api/controller/image/ImageController.java
+++ b/src/main/java/ssafy/retrip/api/controller/image/ImageController.java
@@ -12,7 +12,9 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 import ssafy.retrip.api.controller.image.response.ImageResponseDto;
+import ssafy.retrip.api.controller.image.response.TravelAnalysisResponseDto;
 import ssafy.retrip.api.service.image.ImageService;
+import ssafy.retrip.domain.retrip.Retrip;
 
 @RestController
 @RequestMapping("/api/images")
@@ -26,7 +28,7 @@ public class ImageController {
             @RequestParam("images") List<MultipartFile> images) throws IOException {
         //HttpSession session = request.getSession();
         //String memberId = String.valueOf(session.getAttribute("member"));
-        String memberId = "12344";
+        String memberId = "4277332119";
 
         try {
             System.out.println("✅ 업로드 시작, 파일 수: " + images.size());
@@ -36,8 +38,23 @@ public class ImageController {
             e.printStackTrace();
             return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
         }
+        //TODO 아래와 같은 예시로 변경해주시면 됩니다.
 
-//        List<ImageResponseDto> uploadedImages = imageService.uploadImages(images, memberId);
-//        return ResponseEntity.ok(uploadedImages);
+//        try {
+//            List<ImageResponseDto> uploadedImages = imageService.uploadImages(images, memberId);
+//
+//            // 분석 데이터와 Retrip 객체 가져오기
+//            Retrip retrip = retripService.getLatestRetripByMemberId(memberId);
+//            TravelImageAnalysis analysis = retripService.getTravelAnalysis(retrip.getId());
+//
+//            // 응답 DTO 생성
+//            TravelAnalysisResponseDto responseDto = TravelAnalysisResponseDto.from(analysis, retrip, username);
+//            return ResponseEntity.ok(responseDto);
+//        } catch (Exception e) {
+//            e.printStackTrace();
+//            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+//        }
+
+
     }
 }

--- a/src/main/java/ssafy/retrip/api/controller/image/response/TravelAnalysisResponseDto.java
+++ b/src/main/java/ssafy/retrip/api/controller/image/response/TravelAnalysisResponseDto.java
@@ -1,0 +1,123 @@
+package ssafy.retrip.api.controller.image.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssafy.retrip.api.service.vision.request.AnalysisResponse.TravelImageAnalysis;
+import ssafy.retrip.domain.retrip.Retrip;
+import ssafy.retrip.domain.retrip.TimeSlot;
+
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class TravelAnalysisResponseDto {
+    private UserDto user;
+    private TripSummaryDto tripSummary;
+    private PhotoStatsDto photoStats;
+    private TravelStatsDto travelStats;
+    private List<RecommendationDto> recommendations;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class UserDto {
+        private String username;
+        private String countryCode;
+        private String mbti;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TripSummaryDto {
+        private String summaryLine;
+        private List<String> keywords;
+        private String tripDates;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class PhotoStatsDto {
+        private List<String> favoriteSubjects;
+        private String favoritePhotoSpot;
+        private String favoritePhotoTime;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class TravelStatsDto {
+        private String travelDistance;
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class RecommendationDto {
+        private String emoji;
+        private String place;
+        private String description;
+    }
+
+    // TravelImageAnalysis와 Retrip 정보를 바탕으로 응답 DTO 생성
+    public static TravelAnalysisResponseDto from(TravelImageAnalysis analysis, Retrip retrip, String username) {
+        return TravelAnalysisResponseDto.builder()
+                .user(UserDto.builder()
+                        .username(username)
+                        .countryCode(analysis.getUser().getCountryCode())
+                        .mbti(analysis.getUser().getMbti())
+                        .build())
+                .tripSummary(TripSummaryDto.builder()
+                        .summaryLine(analysis.getTripSummary().getSummaryLine())
+                        .keywords(analysis.getTripSummary().getKeywords())
+                        .tripDates(formatDateRange(retrip.getStartDate(), retrip.getEndDate()))
+                        .build())
+                .photoStats(PhotoStatsDto.builder()
+                        .favoriteSubjects(analysis.getPhotoStats().getFavoriteSubjects())
+                        .favoritePhotoSpot(analysis.getPhotoStats().getFavoritePhotoSpot())
+                        .favoritePhotoTime(getTimeEmoji(retrip.getMainTimeSlot()))
+                        .build())
+                .travelStats(TravelStatsDto.builder()
+                        .travelDistance("총 " + Math.round(retrip.getTotalDistance()) + "km")
+                        .build())
+                .recommendations(retrip.getRecommendations().stream()
+                        .map(rec -> RecommendationDto.builder()
+                                .emoji(rec.getEmoji())
+                                .place(rec.getPlace())
+                                .description(rec.getDescription())
+                                .build())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+
+    private static String formatDateRange(LocalDateTime start, LocalDateTime end) {
+        if (start == null || end == null) return "";
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+        return start.format(formatter) + " - " + end.format(formatter);
+    }
+
+    private static String getTimeEmoji(TimeSlot timeSlot) {
+        if (timeSlot == null) return "⏱️ 알 수 없음";
+
+        switch (timeSlot) {
+            case MORNING: return "🌅 아침";
+            case AFTERNOON: return "🌞 낮";
+            case DAWN: return "🌆 새벽";
+            case NIGHT: return "🌃 밤";
+            default: return "⏱️ 기타";
+        }
+    }
+}

--- a/src/main/java/ssafy/retrip/api/controller/image/response/TravelAnalysisResponseDto.java
+++ b/src/main/java/ssafy/retrip/api/controller/image/response/TravelAnalysisResponseDto.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import ssafy.retrip.api.service.vision.request.AnalysisResponse.TravelImageAnalysis;
+import ssafy.retrip.api.service.vision.response.AnalysisResponse.TravelImageAnalysis;
 import ssafy.retrip.domain.retrip.Retrip;
 import ssafy.retrip.domain.retrip.TimeSlot;
 

--- a/src/main/java/ssafy/retrip/api/service/retrip/ChatGptProxyService.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/ChatGptProxyService.java
@@ -8,7 +8,7 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import ssafy.retrip.api.service.retrip.request.ImageAnalysisRequest;
-import ssafy.retrip.api.service.vision.request.AnalysisResponse;
+import ssafy.retrip.api.service.vision.response.AnalysisResponse;
 
 @Slf4j
 @Service

--- a/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
@@ -10,7 +10,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import ssafy.retrip.api.service.retrip.request.ImageAnalysisRequest;
-import ssafy.retrip.api.service.vision.request.AnalysisResponse;
+import ssafy.retrip.api.service.vision.response.AnalysisResponse;
 import ssafy.retrip.domain.image.Image;
 import ssafy.retrip.domain.member.Member;
 import ssafy.retrip.domain.member.MemberRepository;

--- a/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/RetripService.java
@@ -14,6 +14,7 @@ import ssafy.retrip.api.service.vision.request.AnalysisResponse;
 import ssafy.retrip.domain.image.Image;
 import ssafy.retrip.domain.member.Member;
 import ssafy.retrip.domain.member.MemberRepository;
+import ssafy.retrip.domain.retrip.RecommendationPlace;
 import ssafy.retrip.domain.retrip.Retrip;
 import ssafy.retrip.domain.retrip.RetripRepository;
 import ssafy.retrip.domain.retrip.TimeSlot;
@@ -90,7 +91,7 @@ public class RetripService {
         // 5. 이미지 카운트
         retrip.setImageCount(images.size());
 
-        // 6. ChatGPT API를 사용하여 여행 설명 생성
+        // 6. ChatGPT API를 사용하여 여행 분석 결과 저장
         try {
             ImageAnalysisRequest request = ImageAnalysisRequest.builder()
                 .memberId(memberId)
@@ -102,34 +103,85 @@ public class RetripService {
             AnalysisResponse analysisResponse = chatGptProxyService.getImageAnalysis(request);
 
             if (analysisResponse != null && analysisResponse.getTravelImageAnalysis() != null) {
-                AnalysisResponse.TravelAnalysis travelAnalysis =
-                    analysisResponse.getTravelImageAnalysis().getTravelAnalysis();
-
-                if (travelAnalysis != null) {
-                    // ReTrip 객체에 분석 결과 저장
-                    retrip.setMbti(travelAnalysis.getMbti());
-                    retrip.setOverallMood(travelAnalysis.getOverallMood());
-                    retrip.setPersonMood(travelAnalysis.getPersonMood());
-
-                    // Top 방문 장소 설정
-                    if (travelAnalysis.getTopVisitPlace() != null) {
-                        AnalysisResponse.TopVisitPlace topPlace = travelAnalysis.getTopVisitPlace();
-                        retrip.setTopVisitPlace(topPlace.getPlaceName());
-
-                        // 주요 장소 좌표 정보가 있으면 업데이트
-                        if (topPlace.getLatitude() != null && topPlace.getLongitude() != null) {
-                            retrip.setMainLocationLat(topPlace.getLatitude());
-                            retrip.setMainLocationLng(topPlace.getLongitude());
-                            retrip.setMainLocation(topPlace.getPlaceName());
-                            log.info("분석 결과 주요 장소 업데이트: {}, 좌표: {}, {}",
-                                topPlace.getPlaceName(),
-                                topPlace.getLatitude(),
-                                topPlace.getLongitude());
-                        }
-                    }
-
-                    log.info("이미지 분석 결과 설정 완료: retripId={}", retripId);
+                AnalysisResponse.TravelImageAnalysis travelImageAnalysis = analysisResponse.getTravelImageAnalysis();
+                
+                // User 정보 설정
+                if (travelImageAnalysis.getUser() != null) {
+                    AnalysisResponse.User user = travelImageAnalysis.getUser();
+                    retrip.setCountryCode(user.getCountryCode());
+                    retrip.setMbti(user.getMbti());
+                    log.info("User 정보 설정 완료: countryCode={}, mbti={}", user.getCountryCode(), user.getMbti());
                 }
+
+                // TripSummary 정보 설정
+                if (travelImageAnalysis.getTripSummary() != null) {
+                    AnalysisResponse.TripSummary tripSummary = travelImageAnalysis.getTripSummary();
+                    retrip.setSummaryLine(tripSummary.getSummaryLine());
+                    retrip.setHashtag(tripSummary.getHashtag());
+
+                    // 키워드 리스트 설정
+                    if (tripSummary.getKeywords() != null) {
+                        if (retrip.getKeywords() == null) {
+                            retrip.setKeywords(new ArrayList<>());
+                        }
+                        retrip.getKeywords().clear();
+                        retrip.getKeywords().addAll(tripSummary.getKeywords());
+                    }
+                    
+                    log.info("TripSummary 정보 설정 완료: summaryLine={}, hashtag={}, keywords={}",
+                        tripSummary.getSummaryLine(), tripSummary.getHashtag(), tripSummary.getKeywords());
+                }
+
+                // PhotoStats 정보 설정
+                if (travelImageAnalysis.getPhotoStats() != null) {
+                    AnalysisResponse.PhotoStats photoStats = travelImageAnalysis.getPhotoStats();
+                    retrip.setFavoritePhotoSpot(photoStats.getFavoritePhotoSpot());
+
+                    // 좋아하는 피사체 이모지 리스트 설정
+                    if (photoStats.getFavoriteSubjects() != null) {
+                        if (retrip.getFavoriteSubjects() == null) {
+                            retrip.setFavoriteSubjects(new ArrayList<>());
+                        }
+                        retrip.getFavoriteSubjects().clear();
+                        retrip.getFavoriteSubjects().addAll(photoStats.getFavoriteSubjects());
+                    }
+                    
+                    log.info("PhotoStats 정보 설정 완료: favoritePhotoSpot={}, favoriteSubjects={}",
+                        photoStats.getFavoritePhotoSpot(), photoStats.getFavoriteSubjects());
+                }
+                
+                // 기존 추천 장소 정보 제거
+                if (retrip.getRecommendations() == null) {
+                    retrip.setRecommendations(new ArrayList<>());
+                }
+                retrip.getRecommendations().clear();
+                
+                // Recommendations 정보 설정
+                if (travelImageAnalysis.getRecommendations() != null) {
+                    List<AnalysisResponse.Recommendation> recommendations = travelImageAnalysis.getRecommendations();
+                    
+                    for (AnalysisResponse.Recommendation rec : recommendations) {
+                        RecommendationPlace recommendationPlace = RecommendationPlace.builder()
+                            .emoji(rec.getEmoji())
+                            .place(rec.getPlace())
+                            .description(rec.getDescription())
+                            .build();
+                        
+                        retrip.addRecommendation(recommendationPlace);
+                    }
+                    
+                    log.info("추천 장소 {} 개 설정 완료", recommendations.size());
+                }
+
+                // 여행 이름을 summaryLine으로 설정
+                if (travelImageAnalysis.getTripSummary() != null && 
+                    travelImageAnalysis.getTripSummary().getSummaryLine() != null) {
+                    retrip.setName(travelImageAnalysis.getTripSummary().getSummaryLine());
+                } else {
+                    retrip.setName(generateTripName(null, retrip.getStartDate()));
+                }
+                
+                log.info("이미지 분석 결과 설정 완료: retripId={}", retripId);
             }
         } catch (Exception e) {
             log.error("이미지 분석 결과 처리 중 오류 발생", e);

--- a/src/main/java/ssafy/retrip/api/service/retrip/response/ImageAnalysisResponse.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/response/ImageAnalysisResponse.java
@@ -1,67 +1,67 @@
-package ssafy.retrip.api.service.retrip.response;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
-
-import java.util.List;
-import java.util.Map;
-
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class ImageAnalysisResponse {
-    private List<FailedImageInfo> failed_images_info;
-    private TravelImageAnalysis travel_image_analysis;
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class FailedImageInfo {
-        private String id;
-        private String reason;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TravelImageAnalysis {
-        private TravelAnalysis travel_analysis;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TravelAnalysis {
-        private String mbti;
-        private String overall_mood;
-        private Map<String, String> photo_category_ratio;
-        private List<Subject> top5_subjects;
-        private TopVisitPlace top_visit_place;
-    }
-
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class Subject {
-        private int count;
-        private String subject;
-    }
-    
-    @Data
-    @Builder
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class TopVisitPlace {
-        // 실제 JSON 응답과 일치하도록 필드명 수정
-        private Double latitude;
-        private Double longitude;
-        private String place_name;
-    }
-}
+//package ssafy.retrip.api.service.retrip.response;
+//
+//import lombok.AllArgsConstructor;
+//import lombok.Builder;
+//import lombok.Data;
+//import lombok.NoArgsConstructor;
+//
+//import java.util.List;
+//import java.util.Map;
+//
+//@Data
+//@Builder
+//@NoArgsConstructor
+//@AllArgsConstructor
+//public class ImageAnalysisResponse {
+//    private List<FailedImageInfo> failed_images_info;
+//    private TravelImageAnalysis travel_image_analysis;
+//
+//    @Data
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class FailedImageInfo {
+//        private String id;
+//        private String reason;
+//    }
+//
+//    @Data
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class TravelImageAnalysis {
+//        private TravelAnalysis travel_analysis;
+//    }
+//
+//    @Data
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class TravelAnalysis {
+//        private String mbti;
+//        private String overall_mood;
+//        private Map<String, String> photo_category_ratio;
+//        private List<Subject> top5_subjects;
+//        private TopVisitPlace top_visit_place;
+//    }
+//
+//    @Data
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class Subject {
+//        private int count;
+//        private String subject;
+//    }
+//
+//    @Data
+//    @Builder
+//    @NoArgsConstructor
+//    @AllArgsConstructor
+//    public static class TopVisitPlace {
+//        // 실제 JSON 응답과 일치하도록 필드명 수정
+//        private Double latitude;
+//        private Double longitude;
+//        private String place_name;
+//    }
+//}

--- a/src/main/java/ssafy/retrip/api/service/vision/VisionAnalysisService.java
+++ b/src/main/java/ssafy/retrip/api/service/vision/VisionAnalysisService.java
@@ -5,7 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
-import ssafy.retrip.api.service.vision.request.AnalysisResponse;
+import ssafy.retrip.api.service.vision.response.AnalysisResponse;
 
 @Service
 @Transactional

--- a/src/main/java/ssafy/retrip/api/service/vision/request/AnalysisResponse.java
+++ b/src/main/java/ssafy/retrip/api/service/vision/request/AnalysisResponse.java
@@ -3,7 +3,6 @@ package ssafy.retrip.api.service.vision.request;
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;
 import java.util.List;
-import java.util.Map;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -18,52 +17,47 @@ public class AnalysisResponse {
 
   @Getter
   @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
   public static class FailedImageInfo {
-
     private String id;
     private String reason;
   }
 
   @Getter
   @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
   public static class TravelImageAnalysis {
-
-    private TravelAnalysis travelAnalysis;
+    private User user;
+    private TripSummary tripSummary;
+    private PhotoStats photoStats;
+    private List<Recommendation> recommendations;
   }
 
   @Getter
   @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  public static class TravelAnalysis {
-
+  public static class User {
+    private String countryCode;
     private String mbti;
-    private String overallMood;
-    private String personMood;
-    private Map<String, String> photoCategoryRatio;
-    private List<TopSubject> top5Subjects;
-    private List<String> topRecommendPlace;
-    private TopVisitPlace topVisitPlace;
   }
 
   @Getter
   @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  public static class TopSubject {
-
-    private int count;
-    private String subject;
+  public static class TripSummary {
+    private String summaryLine;
+    private List<String> keywords;
+    private String hashtag;
   }
 
   @Getter
   @NoArgsConstructor
-  @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy.class)
-  public static class TopVisitPlace {
+  public static class PhotoStats {
+    private List<String> favoriteSubjects;
+    private String favoritePhotoSpot;
+  }
 
-    // 실제 JSON 응답과 일치하도록 필드명 수정
-    private Double latitude;
-    private Double longitude;
-    private String placeName;
+  @Getter
+  @NoArgsConstructor
+  public static class Recommendation {
+    private String emoji;
+    private String place;
+    private String description;
   }
 }

--- a/src/main/java/ssafy/retrip/api/service/vision/response/AnalysisResponse.java
+++ b/src/main/java/ssafy/retrip/api/service/vision/response/AnalysisResponse.java
@@ -1,4 +1,4 @@
-package ssafy.retrip.api.service.vision.request;
+package ssafy.retrip.api.service.vision.response;
 
 import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.annotation.JsonNaming;

--- a/src/main/java/ssafy/retrip/domain/retrip/RecommendationPlace.java
+++ b/src/main/java/ssafy/retrip/domain/retrip/RecommendationPlace.java
@@ -1,0 +1,32 @@
+package ssafy.retrip.domain.retrip;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import ssafy.retrip.domain.BaseEntity;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "recommendation_places")
+public class RecommendationPlace extends BaseEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(nullable = false)
+    private String emoji;        // 장소 특성을 나타내는 이모지
+    
+    @Column(nullable = false)
+    private String place;        // 추천 장소명
+    
+    @Column(nullable = false)
+    private String description;  // 장소에 대한 간략한 설명
+    
+    // Retrip과의 관계는 Retrip 엔터티에서 관리
+}

--- a/src/main/java/ssafy/retrip/domain/retrip/Retrip.java
+++ b/src/main/java/ssafy/retrip/domain/retrip/Retrip.java
@@ -49,17 +49,39 @@ public class Retrip extends BaseEntity {
     // 총 이미지 개수
     private Integer imageCount;
 
-    // 여행 설명 (ChatGPT API로 생성 가능)
-    private String description;
-
     // 여행 이름
     private String name;
     
-    // ChatGPT 분석 결과 필드 추가
-    private String mbti;                 // 여행 MBTI 성향
-    private String overallMood;          // 전반적인 여행 분위기 
-    private String topVisitPlace;        // 주요 방문 장소
-    private String personMood;           // 여행 중 사람들의 기분
+    // ChatGPT 분석 결과 필드 - 새 JSON 구조에 맞게 수정
+    // User 정보
+    private String countryCode;   // 방문한 국가의 ISO 코드
+    private String mbti;          // 사용자의 여행 스타일 MBTI
+    
+    // TripSummary 정보
+    private String summaryLine;   // 여행 한 줄 요약(20자 이내)
+    
+    @ElementCollection
+    @CollectionTable(name = "retrip_keywords", joinColumns = @JoinColumn(name = "retrip_id"))
+    @Column(name = "keyword")
+    private List<String> keywords = new ArrayList<>();  // 여행 키워드 3개
+    
+    private String hashtag;       // 단일 단어 해시태그
+    
+    // PhotoStats 정보
+    @ElementCollection
+    @CollectionTable(name = "retrip_favorite_subjects", joinColumns = @JoinColumn(name = "retrip_id"))
+    @Column(name = "subject")
+    private List<String> favoriteSubjects = new ArrayList<>();  // 피사체 이모지 3개
+    
+    private String favoritePhotoSpot;  // 가장 많이 촬영된 장소명
+    
+    // Recommendations 정보 (별도 테이블로 저장)
+    @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "retrip_id")
+    private List<RecommendationPlace> recommendations = new ArrayList<>();
+
+    // 여행 설명 (ChatGPT API로 생성 가능)
+    private String description;
 
     // Image와의 관계 설정 (양방향)
     @OneToMany(mappedBy = "retrip", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -116,5 +138,13 @@ public class Retrip extends BaseEntity {
         if (member != null && !member.getRetrips().contains(this)) {
             member.getRetrips().add(this);
         }
+    }
+    
+    /**
+     * 추천 장소 추가 메서드
+     * @param recommendation 추가할 추천 장소
+     */
+    public void addRecommendation(RecommendationPlace recommendation) {
+        this.recommendations.add(recommendation);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈



## 📝 작업 내용
**최종적으로 ImageController에 만들어 놓은 형식대로 TravelAnalysisResponseDto 를 Front에 반환처리 해주시면됩니다.**
TODO
1. TravelAnalysisResponseDto -> 최종 프론트에 넘겨야할 DTO를 형식을 만들어 두었습니다. User정보 + Retrip에 저장된 내용을 바탕으로 완성해주시면 될 것 같습니다.
2. Front에 잘 넘어가는지 확인

- ChatGPT 통신을 받아오는 객체를 ImageAnalysisResponse에서 -> AnalysisResponse로 변경했습니다. 기존 리스폰스는 주석처리했습니다.
- Retrip 엔티티를 json 받아오는 객체를 저장하기위해 구조를 변경했습니다. 테이블도 여러개 생성될겁니다. create-drop 처음에 해주세요!

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

