### PR TITLE
Feat: 유저가 저장한 Retrip 결과 이미지를 확인할 수 있는 Retrip 히스토리 기능 구현

### DIFF
--- a/src/main/java/ssafy/retrip/api/controller/member/MemberController.java
+++ b/src/main/java/ssafy/retrip/api/controller/member/MemberController.java
@@ -1,10 +1,10 @@
 package ssafy.retrip.api.controller.member;
 
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,6 +18,7 @@ import ssafy.retrip.api.controller.member.request.PasswordFindRequest;
 import ssafy.retrip.api.controller.member.request.PasswordResetRequest;
 import ssafy.retrip.api.service.email.EmailService;
 import ssafy.retrip.api.service.member.MemberService;
+import ssafy.retrip.api.service.retrip.response.ImageUrlResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -72,9 +73,12 @@ public class MemberController {
     return ResponseEntity.ok("비밀번호가 성공적으로 변경되었습니다.");
   }
 
-  // TODO: 회원 리트립 히스토리 조회
-  @GetMapping("/history/{memberId}")
-  public void getHistory(@PathVariable Long memberId) {
+  @GetMapping("/history")
+  public ResponseEntity<List<ImageUrlResponse>> getRetripHistoryByMemberId() {
 
+    String memberId = "4268383655";
+    List<ImageUrlResponse> responses = memberService.getRetripHistoryByMemberId(memberId);
+
+    return ResponseEntity.ok(responses);
   }
 }

--- a/src/main/java/ssafy/retrip/api/service/member/MemberService.java
+++ b/src/main/java/ssafy/retrip/api/service/member/MemberService.java
@@ -2,6 +2,7 @@ package ssafy.retrip.api.service.member;
 
 import static ssafy.retrip.domain.member.LoginType.NORMAL;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -13,8 +14,11 @@ import ssafy.retrip.api.service.member.request.MemberSignInServiceRequest;
 import ssafy.retrip.api.service.member.request.MemberSignUpServiceRequest;
 import ssafy.retrip.api.service.member.request.PasswordFindServiceRequest;
 import ssafy.retrip.api.service.member.request.PasswordResetServiceRequest;
+import ssafy.retrip.api.service.retrip.response.ImageUrlResponse;
 import ssafy.retrip.domain.member.Member;
 import ssafy.retrip.domain.member.MemberRepository;
+import ssafy.retrip.domain.retripReport.RetripReport;
+import ssafy.retrip.domain.retripReport.RetripReportRepository;
 import ssafy.retrip.global.exception.NicknameAlreadyExistsException;
 
 @Service
@@ -25,6 +29,7 @@ public class MemberService {
   private final EmailService emailService;
   private final MemberRepository memberRepository;
   private final BCryptPasswordEncoder passwordEncoder;
+  private final RetripReportRepository retripReportRepository;
 
   @Transactional
   public void signup(MemberSignUpServiceRequest request) {
@@ -89,5 +94,17 @@ public class MemberService {
 
     String encodedPassword = passwordEncoder.encode(request.getNewPassword());
     member.updatePassword(encodedPassword);
+  }
+
+  public List<ImageUrlResponse> getRetripHistoryByMemberId(String memberId) {
+
+    List<RetripReport> retripReports = retripReportRepository.findByMemberId(memberId).orElseThrow(
+        () -> new IllegalStateException("해당 회원의 Retrip 히스토리가 없습니다.")
+    );
+
+    return retripReports.stream()
+        .map(report -> ImageUrlResponse.builder()
+            .imageUrl(report.getImageUrl())
+            .build()).toList();
   }
 }

--- a/src/main/java/ssafy/retrip/api/service/retrip/response/ImageUrlResponse.java
+++ b/src/main/java/ssafy/retrip/api/service/retrip/response/ImageUrlResponse.java
@@ -1,0 +1,18 @@
+package ssafy.retrip.api.service.retrip.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ImageUrlResponse {
+
+  private String imageUrl;
+
+  @Builder
+  private ImageUrlResponse(String imageUrl) {
+    this.imageUrl = imageUrl;
+  }
+}

--- a/src/main/java/ssafy/retrip/api/service/retripReport/RetripReportService.java
+++ b/src/main/java/ssafy/retrip/api/service/retripReport/RetripReportService.java
@@ -1,0 +1,25 @@
+package ssafy.retrip.api.service.retripReport;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import ssafy.retrip.domain.retripReport.RetripReport;
+import ssafy.retrip.domain.retripReport.RetripReportRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RetripReportService {
+
+  private final RetripReportRepository retripReportRepository;
+
+  @Transactional
+  public void saveReportImage(String memberId, String imageUrl) {
+
+    RetripReport report = RetripReport.builder()
+        .memberId(memberId)
+        .imageUrl(imageUrl).build();
+
+    retripReportRepository.save(report);
+  }
+}

--- a/src/main/java/ssafy/retrip/domain/retripReport/RetripReport.java
+++ b/src/main/java/ssafy/retrip/domain/retripReport/RetripReport.java
@@ -1,0 +1,33 @@
+package ssafy.retrip.domain.retripReport;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "retrip_reports")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RetripReport {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String memberId;
+
+  private String imageUrl;
+
+
+  @Builder
+  private RetripReport(String memberId, String imageUrl) {
+    this.memberId = memberId;
+    this.imageUrl = imageUrl;
+  }
+}

--- a/src/main/java/ssafy/retrip/domain/retripReport/RetripReport.java
+++ b/src/main/java/ssafy/retrip/domain/retripReport/RetripReport.java
@@ -9,12 +9,13 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import ssafy.retrip.domain.BaseEntity;
 
 @Getter
 @Entity
 @Table(name = "retrip_reports")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RetripReport {
+public class RetripReport extends BaseEntity {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/ssafy/retrip/domain/retripReport/RetripReportRepository.java
+++ b/src/main/java/ssafy/retrip/domain/retripReport/RetripReportRepository.java
@@ -1,0 +1,19 @@
+package ssafy.retrip.domain.retripReport;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RetripReportRepository extends JpaRepository<RetripReport, Long> {
+
+  @Query(nativeQuery = true,
+      value = "SELECT * "
+              + "FROM retrip_reports "
+              + "WHERE member_id = :memberId"
+  )
+  Optional<List<RetripReport>> findByMemberId(String memberId);
+
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#21 

## 📝 작업 내용

- 유저가 저장한 Retrip 결과 이미지를 확인할 수 있는 히스토리 기능을 구현했습니다.
- 전체적인 동작 흐름은 다음과 같습니다.
  - Retrip 결과 이미지가 완성되면 프론트엔드에서 해당 이미지를 백엔드 서버로 전달합니다.
  - 프론트엔드에서 S3에 저장된 imageUrl 값을 전달하고, 백엔드에서는 전달받은 결과 이미지 Url을 DB에 저장합니다.
  - /history 엔드포인트에서는 memberId 식별값에 대한 모든 Retrip Image Url 값을 List 자료구조에 담아서 반환합니다.
  - Entity 객체에 대해서 식별값과 같은 중요한 정보를 감추기 위해서 stream 기술을 활용하여 List<DTO> 형식으로 담아서 필요한 값만 전달합니다.
- 연관 관계를 맺지 않은 두 테이블 조합하여 데이터를 가져오기 위해서 JPA Native Query 기술을 활용했습니다.
<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

