### PR TITLE
Fix: certbot 인증서 생성 한도 초과 오류 해결 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -111,10 +111,8 @@ services:
     env_file:
       - .env
     volumes:
-      - ./nginx/ssl:/etc/letsencrypt
-      - ./nginx/html:/var/www/certbot
-    entrypoint: >
-      sh -c "certbot certonly --webroot --webroot-path=/var/www/certbot -d retrip.kr -d www.retrip.kr -d api.retrip.kr --email $CERTBOT_EMAIL --agree-tos --no-eff-email --force-renewal"
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
     depends_on:
       - nginx
     networks:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#26 

## 📝 작업 내용

- 인증서 발급 로직 중에서 "--force-renewal" 옵션으로 인하여 인증서를 강제로 재갱신하는 현상이 발생했습니다.
- 그로 인하여 CD 연동 테스트 중 지속적인 인증서 발급으로 certbot 측에서 한도 초과 오류를 발생시켰습니다.
- 해당 옵션을 제거하고, deploy.sh 파일을 수정했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

