### PR TITLE
Refactor: CD workflow 수정 및 모니터링 metric 수집 조건 추가, nginx reverse proxy 연동

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -11,9 +11,7 @@ jobs:
     name: EC2에 배포
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' &&
-      (startsWith(github.event.workflow_run.head_branch, 'feat/') ||
-      github.event.workflow_run.head_branch == 'main' ||
-      github.event.workflow_run.head_branch == 'dev') }}
+      github.event.workflow_run.head_branch == 'main' }}
 
     steps:
       - name: Checkout

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,9 +2,9 @@ name: Retrip CI
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "main", "dev" ]
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "main", "dev" ]
 
 jobs:
   build-and-test:
@@ -45,7 +45,7 @@ jobs:
     name: Docker 이미지를 빌드하고 Push합니다.
     runs-on: ubuntu-latest
     needs: build-and-test
-    if: startsWith(github.head_ref, 'feat/') || github.event_name == 'push'
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main')
 
     steps:
     - uses: actions/checkout@v4
@@ -87,4 +87,10 @@ jobs:
         tags: |
           ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:${{ github.sha }}
           ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPOSITORY }}:latest
+
+    - name: 배포 완료 알림
+      run: |
+        echo "🚀 Docker 이미지가 성공적으로 배포되었습니다!"
+        echo "Branch: ${{ github.ref_name }}"
+        echo "Commit: ${{ github.sha }}"
           

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,8 @@ services:
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
     ports:
       - "9090:9090"
+    networks:
+      - retrip-net
     restart: always
     extra_hosts:
       - "host.docker.internal:host-gateway"
@@ -84,6 +86,8 @@ services:
       - grafana-storage:/var/lib/grafana
     depends_on:
       - prometheus
+    networks:
+      - retrip-net
     restart: always
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER}
@@ -97,10 +101,12 @@ services:
       - "443:443"
     volumes:
       - ./nginx/conf.d:/etc/nginx/conf.d
-      - ./nginx/html:/var/www/certbot
-      - ./nginx/ssl:/etc/letsencrypt
+      - ./data/certbot/conf:/etc/letsencrypt
+      - ./data/certbot/www:/var/www/certbot
     depends_on:
       - retrip-app
+      - prometheus
+      - grafana
     networks:
       - retrip-net
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,3 +132,7 @@ volumes:
 networks:
   retrip-net:
     driver: bridge
+    ipam:
+      config:
+        - subnet: 172.20.0.0/16
+          gateway: 172.20.0.1

--- a/nginx/nginx-cert-setup.conf
+++ b/nginx/nginx-cert-setup.conf
@@ -1,7 +1,7 @@
 # HTTP 서버 (인증서 발급용)
 server {
     listen 80;
-    server_name retrip.kr www.retrip.kr api.retrip.kr;
+    server_name retrip.kr www.retrip.kr api.retrip.kr grafana.retrip.kr prometheus.retrip.kr;
 
     location /.well-known/acme-challenge/ {
         root /var/www/certbot;

--- a/nginx/nginx-prod.conf
+++ b/nginx/nginx-prod.conf
@@ -1,7 +1,7 @@
 # HTTP 서버 (인증서 발급용)
 server {
     listen 80;
-    server_name retrip.kr www.retrip.kr api.retrip.kr;
+    server_name retrip.kr www.retrip.kr api.retrip.kr grafana.retrip.kr prometheus.retrip.kr;
 
     client_max_body_size 100M; # user input image file max size
 
@@ -96,6 +96,91 @@ server {
         }
 
         proxy_pass http://retrip-app:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # 타임아웃 설정
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}
+
+# Grafana 서브도메인용 서버
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name grafana.retrip.kr;
+
+    ssl_certificate /etc/letsencrypt/live/retrip.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/retrip.kr/privkey.pem;
+
+    # SSL 보안 설정
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # 보안 헤더 (Grafana용 조정)
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    # Grafana는 iframe을 사용할 수 있으므로 X-Frame-Options를 SAMEORIGIN으로 설정
+    add_header X-Frame-Options SAMEORIGIN always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # IP 화이트리스트 설정
+    include /etc/nginx/conf.d/allowed_ips.conf;
+
+    # Grafana 프록시
+    location / {
+        proxy_pass http://grafana:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # WebSocket 지원 (Grafana Live 기능용)
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # 타임아웃 설정
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}
+
+# Prometheus 서브도메인용 서버
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name prometheus.retrip.kr;
+
+    ssl_certificate /etc/letsencrypt/live/retrip.kr/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/retrip.kr/privkey.pem;
+
+    # SSL 보안 설정
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-RSA-AES128-SHA256:ECDHE-RSA-AES256-SHA384;
+    ssl_prefer_server_ciphers off;
+    ssl_session_cache shared:SSL:10m;
+    ssl_session_timeout 10m;
+
+    # 보안 헤더
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+    add_header X-Frame-Options DENY always;
+    add_header X-XSS-Protection "1; mode=block" always;
+
+    # IP 화이트리스트 설정
+    include /etc/nginx/conf.d/allowed_ips.conf;
+
+    # Prometheus 프록시
+    location / {
+        proxy_pass http://prometheus:9090;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/nginx/nginx-prod.conf
+++ b/nginx/nginx-prod.conf
@@ -86,6 +86,14 @@ server {
     add_header X-Frame-Options DENY always;
     add_header X-XSS-Protection "1; mode=block" always;
 
+    # 내부 네트워크 허용
+    allow 192.168.0.0/16;
+    allow 172.16.0.0/12;
+    allow 127.0.0.1;
+
+    # IP 화이트리스트
+    include /etc/nginx/conf.d/allowed_ips.conf;
+
     # 백엔드 API 프록시
     location / {
         # OPTIONS 요청 처리

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,29 +15,37 @@ spring:
 # prometheus & actuator
 management:
   endpoints:
+    shutdown:
+      enabled: false
     web:
       exposure:
         include: health,info,prometheus
   metrics:
     tags:
       application: retrip-api
-    export:
-      prometheus:
-        enabled: true
     distribution:
       percentiles-histogram:
         http.server.requests: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true
 
-# ReTrip 애플리케이션 설정
+# ReTrip Application Config
 retrip:
   image:
     min-count: 5
     max-count: 20
 
 server:
+  # Session Config
   servlet:
     session:
       timeout: 60m
+  # Tomcat Metric Setting
+  tomcat:
+    mbeanregistry:
+      enabled: true
 
 openai:
   api-key: ${openai.api-key}

--- a/src/main/resources/prometheus.yml
+++ b/src/main/resources/prometheus.yml
@@ -3,7 +3,11 @@ global:
   evaluation_interval: 15s
 
 scrape_configs:
-  - job_name: 'spring-boot-app'
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: [ "prometheus:9090" ]
+
+  - job_name: 'retrip-actuator'
     metrics_path: '/actuator/prometheus'
     static_configs:
-      - targets: [ 'host.docker.internal:8080' ]
+      - targets: [ 'retrip-app:8080' ]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#38 

## 📝 작업 내용

### CI 작업 관련 
- PR 트리거에도 CI workflow 작업이 동작하는 것을 확인했습니다.
- PR은 검증되지 않은 작업입니다. 때문에 PR을 팀원들끼리 읽고, push & merge 할 때 CI 작업을 하는 것이 옳다고 생각하여 수정했습니다.

### CD 작업 관련 
- CD workflow 작업을 main 브랜치에서의 작업이 완료될 때에만 작동되도록 트리거를 수정했습니다.

### metric 관련 
- tomcat 메트릭을 수집하기 위해서 application.yml 파일에 옵션을 추가했습니다.
- tomcat.mbeanregistry 옵션을 통해서 톰캣의 최대 쓰레드, 사용 쓰레드 수를 포함한 다양한 메트릭을 확인할 수 있습니다.

### Prometheus 관련 
- export.prometheus 형식이 deprecated 되어 업데이트 된 형식으로 수정했습니다.
- shutdown 조건에 접근할 수 없도록 shutdown 옵션을 enabled: false 처리했습니다.

### Nginx 관련 
- 프로메테우스, 그라파나 모니터링 도구를 Docker 환경에서 접근할 수 있도록 nginx reverse Proxy 설정했습니다.
 - prometheus.retrip.kr -> reverse proxy -> prometheus:9090
 - grafana.retrip.kr -> reveres proxy -> grafana:3000
- 프로메테우스, 그라파나 서브 도메인에 대해서 SSL 인증서를 발급받아 HTTPS 환경을 구성했습니다.
- 모니터링 도구 및 외부 API 접근에 대해서 특정 IP 주소에서만 접근이 가능하도록 white ip list를 만들어 보안을 강화했습니다.

### docker-compose.yml / deploy.sh 관련 
- 그에 따라 docker-compose.yml 파일 변경 및 deploy.sh 자동화 배포 스크립트를 수정했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

모니터링 도구 접근에 있어 보안을 강화하기 위해 실제 작업하는 공간의 IP 주소를 기반으로 화이트 리스트로 두었습니다. 작업하는 공간이 아닌 곳에서 접근이 불가능하다는 단점이 있는데, 이에 대해서 더 좋은 방법이 어떤 것이 있을지 검토해주시면 감사하겠습니다.
<br/>

