### PR TITLE
Refactor: IP 화이트 리스트 설정으로 모니터링 도구 접근 제한

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,6 @@ services:
       - dbdata:/var/lib/mysql
       - ./docker/mysql/init.sql:/docker-entrypoint-initdb.d/init.sql
       - ./docker/mysql/mysql-healthcheck.sh:/usr/local/bin/mysql-healthcheck.sh
-
     networks:
       - retrip-net
     restart: always
@@ -66,7 +65,10 @@ services:
     image: prom/prometheus
     container_name: prometheus
     volumes:
+      - ./data/prometheus:/prometheus
       - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    depends_on:
+      - retrip-app
     ports:
       - "9090:9090"
     networks:
@@ -83,6 +85,7 @@ services:
     ports:
       - "3000:3000"
     volumes:
+      - ./data/grafana:/var/lib/grafana
       - grafana-storage:/var/lib/grafana
     depends_on:
       - prometheus
@@ -131,6 +134,7 @@ volumes:
 
 networks:
   retrip-net:
+    name: retrip-net
     driver: bridge
     ipam:
       config:

--- a/nginx/nginx-prod.conf
+++ b/nginx/nginx-prod.conf
@@ -86,17 +86,10 @@ server {
     add_header X-Frame-Options DENY always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # 내부 네트워크 허용
-    allow 192.168.0.0/16;
-    allow 172.16.0.0/12;
-    allow 127.0.0.1;
-
-    # IP 화이트리스트
-    include /etc/nginx/conf.d/allowed_ips.conf;
-
     # 백엔드 API 프록시
     location / {
-        # OPTIONS 요청 처리
+
+	# OPTIONS 요청 처리
         if ($request_method = 'OPTIONS') {
             add_header Content-Length 0;
             add_header Content-Type text/plain;
@@ -139,12 +132,12 @@ server {
     add_header X-Frame-Options SAMEORIGIN always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # IP 화이트리스트 설정
-    include /etc/nginx/conf.d/allowed_ips.conf;
+    # IP 화이트리스트
+    include /etc/nginx/conf.d/allowed_ips.rules;
 
-    # Grafana 프록시
     location / {
-        proxy_pass http://grafana:3000;
+
+	proxy_pass http://grafana:3000;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -183,12 +176,13 @@ server {
     add_header X-Frame-Options DENY always;
     add_header X-XSS-Protection "1; mode=block" always;
 
-    # IP 화이트리스트 설정
-    include /etc/nginx/conf.d/allowed_ips.conf;
+    # IP 화이트리스트
+    include /etc/nginx/conf.d/allowed_ips.rules;
 
     # Prometheus 프록시
     location / {
-        proxy_pass http://prometheus:9090;
+
+	proxy_pass http://prometheus:9090;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

issue #32

## 📝 작업 내용

- 프로메테우스, 그라파나 모니터링 도구의 접근을 IP 기반 접근 제한을 두었습니다.
- 2명의 개발자의 작업공간 공인 IP 에서만 접근이 가능합니다.
- deploy.sh 자동화 쉘 스크립트를 실행했을 때, 화이트 리스트를 적용하기 위해서 동작을 수정했습니다.
- deploy.sh 실행 시, Permission denied 오류를 해결하기 위해서 sudo 명령어를 추가했습니다.

<br/>

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>

